### PR TITLE
Fix: add recipe mock toe item and user specs so happy paths tests work

### DIFF
--- a/spec/features/items/new_spec.rb
+++ b/spec/features/items/new_spec.rb
@@ -10,6 +10,11 @@ RSpec.describe 'Add new item to fridge' do
                 Item.new(item_data)
             end
             allow(UserFacade).to receive(:user_items).and_return(items)
+            recipe_json = JSON.parse(File.read('./spec/fixtures/recipe_data.json'), symbolize_names: true) 
+            recipes = recipe_json[:data].map do |recipe_data|
+                Recipe.new(recipe_data)
+            end
+            allow(RecipeFacade).to receive(:find_recipes).and_return(recipes)
         end
         it "has a form to add a new item" do
 

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe 'User dashboard' do
         Item.new(item_data)
       end
       allow(UserFacade).to receive(:user_items).and_return(items)
+
+      recipe_json = JSON.parse(File.read('./spec/fixtures/recipe_data.json'), symbolize_names: true) 
+      recipes = recipe_json[:data].map do |recipe_data|
+        Recipe.new(recipe_data)
+      end
+      allow(RecipeFacade).to receive(:find_recipes).and_return(recipes)
     end
     it 'displays user name and welcome message' do
       visit '/dashboard'
@@ -46,11 +52,7 @@ RSpec.describe 'User dashboard' do
     end
 
     it "displays top 10 recipies" do
-      recipe_json = JSON.parse(File.read('./spec/fixtures/recipe_data.json'), symbolize_names: true) 
-      recipes = recipe_json[:data].map do |recipe_data|
-        Recipe.new(recipe_data)
-      end
-      allow(RecipeFacade).to receive(:find_recipes).and_return(recipes)
+
       visit '/dashboard'
 
       expect(page).to have_content('Buffalo Chicken Wings Wonton Wraps')


### PR DESCRIPTION
### What does this PR do?
- Adds mocks in the items new spec and the user show spec for recipes so that the visit dashboard line works in the tests
### Does this PR break anything?
- [ ] Yes
- [x] No
- If yes, explain:
